### PR TITLE
거래 내역 서버 - 경매 서버 조회 연동 로직 추가

### DIFF
--- a/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Request/AuctionInfoRequest.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Request/AuctionInfoRequest.java
@@ -57,14 +57,4 @@ public record AuctionInfoRequest(
         validateMaximumPurchaseLimitCount(maximumPurchaseLimitCount);
         validateVariationDuration(variationDuration);
     }
-
-
-    public void validate() {
-        validateProductName(productName);
-        validateOriginPrice(originPrice);
-        validateCurrentPrice(currentPrice);
-        validateStock(stock);
-        validateMaximumPurchaseLimitCount(maximumPurchaseLimitCount);
-        validateVariationDuration(variationDuration);
-    }
 }

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Response/ReceiptInfoResponse.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Response/ReceiptInfoResponse.java
@@ -1,4 +1,22 @@
 package org.indoles.autionserviceserver.core.auction.dto.Response;
 
-public record ReceiptInfoResponse() {
+import lombok.Builder;
+import org.indoles.autionserviceserver.core.auction.domain.enums.ReceiptStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record ReceiptInfoResponse(
+        UUID receiptId,
+        String productName,
+        long price,
+        long quantity,
+        ReceiptStatus receiptStatus,
+        long auctionId,
+        long sellerId,
+        long buyerId,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
 }

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/utils/MemberFeignClient.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/utils/MemberFeignClient.java
@@ -1,8 +1,6 @@
 package org.indoles.autionserviceserver.core.auction.utils;
 
-import org.indoles.autionserviceserver.core.auction.controller.interfaces.Login;
 import org.indoles.autionserviceserver.core.auction.dto.Request.RefundRequest;
-import org.indoles.autionserviceserver.core.auction.dto.Request.SignInfoRequest;
 import org.indoles.autionserviceserver.core.auction.dto.Request.TransferPointRequest;
 import org.indoles.autionserviceserver.core.auction.dto.Response.RefundResponse;
 import org.indoles.autionserviceserver.core.auction.dto.Response.TransferPointResponse;

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/utils/ReceiptFeignClient.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/utils/ReceiptFeignClient.java
@@ -18,10 +18,9 @@ public interface ReceiptFeignClient {
             @RequestBody CreateReceiptRequest request
     );
 
-
-    @GetMapping("/receipts/find/{userId}")
-    List<TransactionInfoResponse> getReceiptsByUserId(@PathVariable("userId") UUID userId);
-
     @GetMapping("/receipts/find/{receiptId}")
-    ReceiptInfoResponse getReceiptById(@PathVariable("receiptId") UUID receiptId);
+    ReceiptInfoResponse getReceiptById(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable("receiptId") UUID receiptId
+    );
 }


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 경매 서버와 거래 내역 서버 환불 시 필요한 조회 연동 로직을 추가한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  경매 서버 - 거래 내역 서버 환불 시 조회 연동 로직 추가

---