### PR TITLE
경매 - 거래 내역 서버 업데이트 연동, 경매 서버 - 회원 서버 포인트 환불 로직 작성

### DIFF
--- a/src/main/java/org/indoles/autionserviceserver/core/auction/controller/BuyerAuctionController.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/controller/BuyerAuctionController.java
@@ -6,6 +6,8 @@ import org.indoles.autionserviceserver.core.auction.controller.currentTime.Curre
 import org.indoles.autionserviceserver.core.auction.controller.interfaces.Buyer;
 import org.indoles.autionserviceserver.core.auction.controller.interfaces.Login;
 import org.indoles.autionserviceserver.core.auction.controller.interfaces.PublicAccess;
+import org.indoles.autionserviceserver.core.auction.controller.interfaces.Roles;
+import org.indoles.autionserviceserver.core.auction.domain.enums.Role;
 import org.indoles.autionserviceserver.core.auction.dto.Request.*;
 import org.indoles.autionserviceserver.core.auction.dto.Response.BuyerAuctionInfoResponse;
 import org.indoles.autionserviceserver.core.auction.dto.Response.BuyerAuctionSimpleInfoResponse;
@@ -49,7 +51,7 @@ public class BuyerAuctionController {
     @PublicAccess
     @GetMapping("/{auctionId}")
     public ResponseEntity<BuyerAuctionInfoResponse> getAuction(
-            @PathVariable("auctionId") Long auctionId) {
+            @PathVariable(name = "auctionId") Long auctionId) {
 
         BuyerAuctionInfoResponse result = buyerService.getBuyerAuction(auctionId);
         return ResponseEntity.ok(result);
@@ -85,13 +87,13 @@ public class BuyerAuctionController {
      * 경매 입찰 취소 API(구매자 전용)
      */
     @Buyer
-    @DeleteMapping("/{auctionId}/refund")
+    @DeleteMapping("/{receiptId}/refund")
     public ResponseEntity<Void> cancelAuction(
             @Login SignInfoRequest signInfoRequest,
-            @PathVariable("auctionId") UUID auctionId,
+            @PathVariable(name = "receiptId") UUID receiptId,
             @CurrentTime LocalDateTime localDateTime) {
 
-        var message = new AuctionRefundRequestMessage(signInfoRequest, auctionId, localDateTime);
+        var message = new AuctionRefundRequestMessage(signInfoRequest, receiptId, localDateTime);
         buyerService.cancelPurchase(message);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/domain/Auction.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/domain/Auction.java
@@ -3,6 +3,7 @@ package org.indoles.autionserviceserver.core.auction.domain;
 import lombok.Builder;
 import lombok.Getter;
 
+import lombok.extern.slf4j.Slf4j;
 import org.indoles.autionserviceserver.core.auction.domain.enums.AuctionStatus;
 import org.indoles.autionserviceserver.core.auction.domain.validate.ValidateAuction;
 import org.indoles.autionserviceserver.global.exception.BadRequestException;
@@ -14,7 +15,7 @@ import java.time.LocalDateTime;
 
 import static org.indoles.autionserviceserver.core.auction.domain.validate.ValidateAuction.*;
 
-
+@Slf4j
 @Getter
 public class Auction {
 
@@ -117,6 +118,8 @@ public class Auction {
         verifyPurchaseQuantity(quantity);
 
         this.currentStock -= quantity;
+        this.currentPrice = price;
+        log.debug("Updated current price to: {}", this.currentPrice);
     }
 
     private void verifyCurrentPrice(long inputPrice, LocalDateTime requestTime) {
@@ -125,6 +128,7 @@ public class Auction {
         long actualPrice = pricePolicy.calculatePriceAtVariation(originPrice, currentVariationCount);
 
         validateBuyPrice(actualPrice, inputPrice);
+        this.currentPrice = inputPrice;
     }
 
     private void verifyPurchaseQuantity(long quantity) {

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Request/RefundRequest.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/dto/Request/RefundRequest.java
@@ -1,5 +1,8 @@
 package org.indoles.autionserviceserver.core.auction.dto.Request;
 
+import lombok.Builder;
+
+@Builder
 public record RefundRequest(
         Long receiverId,
         Long amount

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/utils/MemberFeignClient.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/utils/MemberFeignClient.java
@@ -18,6 +18,9 @@ public interface MemberFeignClient {
             @RequestBody TransferPointRequest transferPointRequest);
 
     @PostMapping("/members/points/refund")
-    RefundResponse refundPoint(@RequestBody RefundRequest refundRequest);
+    RefundResponse refundPoint(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody RefundRequest refundRequest
+    );
 }
 

--- a/src/main/java/org/indoles/autionserviceserver/core/auction/utils/ReceiptFeignClient.java
+++ b/src/main/java/org/indoles/autionserviceserver/core/auction/utils/ReceiptFeignClient.java
@@ -23,4 +23,10 @@ public interface ReceiptFeignClient {
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable("receiptId") UUID receiptId
     );
+
+    @PutMapping("/receipts/refund/{receiptId}")
+    void refundReceipt(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable("receiptId") UUID receiptId
+    );
 }

--- a/src/main/java/org/indoles/autionserviceserver/global/util/Mapper.java
+++ b/src/main/java/org/indoles/autionserviceserver/global/util/Mapper.java
@@ -2,6 +2,7 @@ package org.indoles.autionserviceserver.global.util;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.indoles.autionserviceserver.core.auction.domain.Auction;
 import org.indoles.autionserviceserver.core.auction.dto.Request.AuctionInfoRequest;
 import org.indoles.autionserviceserver.core.auction.dto.Response.BuyerAuctionInfoResponse;
@@ -10,6 +11,7 @@ import org.indoles.autionserviceserver.core.auction.dto.Response.SellerAuctionIn
 import org.indoles.autionserviceserver.core.auction.dto.Response.SellerAuctionSimpleInfoResponse;
 import org.indoles.autionserviceserver.core.auction.entity.AuctionEntity;
 
+@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Mapper {
     public static AuctionInfoRequest convertToAuctionInfo(Auction auction) {
@@ -103,6 +105,7 @@ public class Mapper {
     }
 
     public static BuyerAuctionSimpleInfoResponse convertToBuyerAuctionSimpleInfo(Auction auction) {
+        log.debug("Converting auction: {} with current price: {}", auction.getId(), auction.getCurrentPrice());
         return new BuyerAuctionSimpleInfoResponse(
                 auction.getId(),
                 auction.getProductName(),


### PR DESCRIPTION
## 👨‍💻 작업 사항

### 📑 PR 개요
<!-- PR에 대한 간단한 개요를 작성 -->
- 경매 서버와 회원 서버간 환불을 연동하는 로직을 추가한다.
- 경매 서버와 회원 서버간 환불을 연동하는 로직을 추가한다.

---

<!-- 이슈에서 지정했던 작업 목록의 완료 상태를 표시 -->
### ✅ 작업 목록
- [X]  경매 서버 - 회원 서버 환불 연동로직 추가
- [X] 경매 서버 - 회원 서버 환불 연동로직 추가

---